### PR TITLE
opening terminal with a command function and tests added

### DIFF
--- a/app/electron/events/events.js
+++ b/app/electron/events/events.js
@@ -1,0 +1,1 @@
+exports.MakeFileRequest = "Make-File";

--- a/app/electron/events/index.js
+++ b/app/electron/events/index.js
@@ -1,0 +1,78 @@
+const { MakeFileRequest } = require("./events");
+const newFile = require("./newFile");
+
+const validSendChannels = [MakeFileRequest];
+const validReceiveChannels = [MakeFileRequest];
+const { log } = console;
+const debug = true;
+
+// THis is in front end
+// logs will appear in dev tools console
+// This first filters channels / type of requests
+// and if valid, only then passes on to backend
+exports.preloadBindings = (ipcRenderer /* fs */) => {
+  return {
+    send: (channel, filename) => {
+      if (validSendChannels.includes(channel)) {
+        switch (channel) {
+          case MakeFileRequest:
+            if (debug) {
+              log(`requesting to make file '${filename}'`);
+            }
+
+            ipcRenderer.send(channel, {
+              filename,
+            });
+            break;
+          default:
+            break;
+        }
+      } else {
+        log(`Invalid channel ${channel}`);
+      }
+    },
+    onReceive: (channel, func) => {
+      if (validReceiveChannels.includes(channel)) {
+        // Deliberately strip event as it includes "sender"
+        ipcRenderer.on(channel, (/* event, */ args) => {
+          if (debug) {
+            switch (channel) {
+              case MakeFileRequest:
+                log(`received file name '${args.filename}'`);
+                break;
+              default:
+                break;
+            }
+          }
+          func(args);
+        });
+      }
+    },
+    clearRendererBindings: () => {
+      // Clears all listeners
+      if (debug) {
+        log(`clearing all ipcRenderer listeners.`);
+      }
+
+      for (let i = 0; i < validReceiveChannels.length; i += 1) {
+        ipcRenderer.removeAllListeners(validReceiveChannels[i]);
+      }
+    },
+  };
+};
+
+// This is in backend
+// The logs will appear in console where npm run dev is done
+// this checks if channel are valid as well and takes actual actions
+exports.mainBindings = (ipcMain /* , browserWindow, fs, mpc */) => {
+  ipcMain.on(MakeFileRequest, (/* IpcMainEvent, */ args) => {
+    if (debug) {
+      log(
+        `received a request to read store in electron main process.${JSON.stringify(
+          args
+        )}`
+      );
+      newFile(args.filename);
+    }
+  });
+};

--- a/app/electron/events/newFile.js
+++ b/app/electron/events/newFile.js
@@ -1,0 +1,8 @@
+const fs = require("fs");
+
+const { log } = console;
+module.exports = (filename) => {
+  log(`Calling my file function with filename ${filename}`);
+  log("Accessing fs :", fs.existsSync("./app/electron/my-functions"));
+  log("Exiting my file function");
+};

--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -21,8 +21,8 @@ const ContextMenu = require("secure-electron-context-menu").default;
 const { parse, join } = require("path");
 const fs = require("fs");
 const log = require("electron-log");
-// const { sync } = require("glob");
 const electronDebug = require("electron-debug");
+const events = require("./events");
 const { scheme, requestHandler } = require("./protocol");
 const MenuBuilder = require("./menu");
 // To check inbuilt programs are installed or not
@@ -100,11 +100,6 @@ async function createWindow() {
     // so I don't have to write another 'if' statement
     protocol.registerBufferProtocol(scheme, requestHandler);
   }
-  const loadMainProcess = () => {
-    // const files = sync(join(__dirname, "mainEvents/**/*.js"));
-    // files.forEach((file) => require(file));
-  };
-  loadMainProcess();
   const store = new Store({
     path: app.getPath("userData"),
   });
@@ -163,7 +158,7 @@ async function createWindow() {
       },
     ],
   });
-
+  events.mainBindings(ipcMain, win, fs, callback);
   // Load app
   if (isDev) {
     win.loadURL(selfHost);

--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -103,7 +103,6 @@ async function createWindow() {
   const store = new Store({
     path: app.getPath("userData"),
   });
-  events.mainBindings(ipcMain, win, fs, callback);
   // Use saved config values for configuring your
   // BrowserWindow, for instance.
   // NOTE - this config is not passcode protected

--- a/app/electron/main.js
+++ b/app/electron/main.js
@@ -21,8 +21,8 @@ const ContextMenu = require("secure-electron-context-menu").default;
 const { parse, join } = require("path");
 const fs = require("fs");
 const log = require("electron-log");
-// const { sync } = require("glob");
 const electronDebug = require("electron-debug");
+const events = require("./events");
 const { scheme, requestHandler } = require("./protocol");
 const MenuBuilder = require("./menu");
 // To check inbuilt programs are installed or not
@@ -100,14 +100,10 @@ async function createWindow() {
     // so I don't have to write another 'if' statement
     protocol.registerBufferProtocol(scheme, requestHandler);
   }
-  const loadMainProcess = () => {
-    // const files = sync(join(__dirname, "mainEvents/**/*.js"));
-    // files.forEach((file) => require(file));
-  };
-  loadMainProcess();
   const store = new Store({
     path: app.getPath("userData"),
   });
+  events.mainBindings(ipcMain, win, fs, callback);
   // Use saved config values for configuring your
   // BrowserWindow, for instance.
   // NOTE - this config is not passcode protected

--- a/app/electron/mainEvents/hello/hello.js
+++ b/app/electron/mainEvents/hello/hello.js
@@ -1,7 +1,0 @@
-/**
- * const { ipcMain } = require('electron');
- * ipcMain.on('hello', (event, name) => {
- *  console.log('hello',name);
- *  event.reply('college','djsce');
- * });
- */

--- a/app/electron/platform/index.js
+++ b/app/electron/platform/index.js
@@ -1,0 +1,9 @@
+const openTermWindows = require("./windows/openTerm.js");
+const openTermLinux = require("./linux/openTerm.js");
+
+const { platform } = process;
+if (platform === "linux") {
+  exports.openTerm = openTermLinux;
+} else if (platform === "win32") {
+  exports.openTerm = openTermWindows;
+}

--- a/app/electron/platform/linux/openTerm.js
+++ b/app/electron/platform/linux/openTerm.js
@@ -7,9 +7,9 @@ const xTerm = "xterm -fa 'Monospace' -fs 12 -e /bin/bash -l -c ";
 const insertCommandLinux = (arrCommand, type) => {
   const command = arrCommand.join(" ");
   if (type === "xterm") {
-    return `${`${xTerm}'${command}`};/bin/bash'`;
+    return `${`${xTerm}'${command}`}; exec $SHELL'`;
   }
-  return `${`${gnomeTerminal}'${command}`}; exec bash'`;
+  return `${`${gnomeTerminal}'${command}`}; exec $SHELL'`;
 };
 module.exports = (arrCommand, type = "gnomeTerminal") => {
   return new Promise((resolve, reject) => {

--- a/app/electron/platform/linux/openTerm.js
+++ b/app/electron/platform/linux/openTerm.js
@@ -1,0 +1,23 @@
+const { exec } = require("child_process");
+
+const gnomeTerminal = "gnome-terminal --tab --active -- bash -c ";
+const xTerm = "xterm -fa 'Monospace' -fs 12 -e /bin/bash -l -c ";
+// append command to xTerm and then append ';exec bash';
+// append command to gnomeTerminal and then append '; exec bash'
+const insertCommandLinux = (arrCommand, type) => {
+  const command = arrCommand.join(" ");
+  if (type === "xterm") {
+    return `${`${xTerm}'${command}`};/bin/bash'`;
+  }
+  return `${`${gnomeTerminal}'${command}`}; exec bash'`;
+};
+module.exports = (arrCommand, type = "gnomeTerminal") => {
+  return new Promise((resolve, reject) => {
+    const executableString = insertCommandLinux(arrCommand, type);
+    exec(executableString, (err) => {
+      if (err) {
+        reject(err);
+      } else resolve(0);
+    });
+  });
+};

--- a/app/electron/platform/windows/openTerm.js
+++ b/app/electron/platform/windows/openTerm.js
@@ -1,0 +1,24 @@
+const { spawn } = require("child_process");
+
+const cmd = ["/k", "start", "cmd.exe", "/k"];
+
+const insertCommandWin = (arrCommand) => {
+  return cmd.concat(arrCommand);
+};
+
+module.exports = (arrCommand) => {
+  return new Promise((resolve, reject) => {
+    const executableArray = insertCommandWin(arrCommand);
+    const child = spawn("cmd", executableArray, {
+      detached: true,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    child.on("error", (err) => {
+      reject(err);
+    });
+    child.on("exit", () => {
+      resolve(0);
+    });
+    child.unref();
+  });
+};

--- a/app/electron/preload.js
+++ b/app/electron/preload.js
@@ -4,8 +4,7 @@ const i18nextBackend = require("i18next-electron-fs-backend");
 const Store = require("secure-electron-store").default;
 const ContextMenu = require("secure-electron-context-menu").default;
 const log = require("electron-log");
-
-//  const { sendHello,getCollege } = require("./renderEvents");
+const events = require("./events");
 // Create the electron store to be made available in the renderer process
 const store = new Store();
 
@@ -15,8 +14,7 @@ contextBridge.exposeInMainWorld("api", {
   i18nextElectronBackend: i18nextBackend.preloadBindings(ipcRenderer),
   store: store.preloadBindings(ipcRenderer, fs),
   contextMenu: ContextMenu.preloadBindings(ipcRenderer),
-  //  send: name => sendHello(name),
-  //  get: ()=> getCollege(),
+  api: events.preloadBindings(ipcRenderer, fs),
 });
 // Logging
 window.log = log.functions;

--- a/app/electron/renderEvents/index.js
+++ b/app/electron/renderEvents/index.js
@@ -1,8 +1,0 @@
-/**
- * exports.functionToSendData = require("./sendingData").sendData;
- * Now inside sendingData.js
- * const { ipcRenderer } = require('electron');
- * exports.getCollege = () => ipcRenderer.once('college',
- * (event,data) => console.log(data));
- * exports.sendHello = data => ipcRenderer.send("hello", data);
- */

--- a/test/openTerm.js
+++ b/test/openTerm.js
@@ -2,34 +2,27 @@ const { existsSync, unlink } = require("fs");
 const { assert } = require("chai");
 const { after } = require("mocha");
 const log = require("electron-log");
-const openTermLinux = require("../app/electron/platform/linux/openTerm");
-const openTermWin = require("../app/electron/platform/windows/openTerm");
+const { openTerm } = require("../app/electron/platform");
 
 after(() => {
   unlink("./test.txt", (err) => {
-    if (err) log.error(err);
-    else log.info("Test completed and file deleted");
+    if (err) {
+      log.error(err);
+    } else {
+      log.info("Test completed and file deleted");
+    }
   });
 });
-if (process.platform === "linux") {
-  describe("Open Terminal", () => {
-    it("Should open terminal and create file [test.txt]", async () => {
-      const arrCommandType = ["touch", "./test.txt"];
-      await openTermLinux(arrCommandType);
-      const isFile = existsSync("./test.txt");
-      assert(isFile, true);
-    });
+describe("Open Terminal", () => {
+  it("Should open terminal and create file [test.txt]", async () => {
+    let arrCommandType;
+    if (process.platform === "linux") {
+      arrCommandType = ["touch", "./test.txt"];
+    } else if (process.platform === "win32") {
+      arrCommandType = ["echo", ".>", "test.txt"];
+    }
+    await openTerm(arrCommandType);
+    const isFile = existsSync("./test.txt");
+    assert(isFile, true);
   });
-} else if (process.platform === "win32") {
-  describe("Open Terminal", () => {
-    it("Should open terminal and create file [test.txt]", async () => {
-      const arrCommandType = ["echo", ".>", "test.txt"];
-      await openTermWin(arrCommandType);
-      const isFile = existsSync("./test.txt");
-      assert(isFile, true);
-    });
-  });
-  /* this test cannot delete the file because the cmd
-   * spawned keeps the file created open
-   */
-}
+});

--- a/test/openTerm.js
+++ b/test/openTerm.js
@@ -1,0 +1,35 @@
+const { existsSync, unlink } = require("fs");
+const { assert } = require("chai");
+const { after } = require("mocha");
+const log = require("electron-log");
+const openTermLinux = require("../app/electron/platform/linux/openTerm");
+const openTermWin = require("../app/electron/platform/windows/openTerm");
+
+after(() => {
+  unlink("./test.txt", (err) => {
+    if (err) log.error(err);
+    else log.info("Test completed and file deleted");
+  });
+});
+if (process.platform === "linux") {
+  describe("Open Terminal", () => {
+    it("Should open terminal and create file [test.txt]", async () => {
+      const arrCommandType = ["touch", "./test.txt"];
+      await openTermLinux(arrCommandType);
+      const isFile = existsSync("./test.txt");
+      assert(isFile, true);
+    });
+  });
+} else if (process.platform === "win32") {
+  describe("Open Terminal", () => {
+    it("Should open terminal and create file [test.txt]", async () => {
+      const arrCommandType = ["echo", ".>", "test.txt"];
+      await openTermWin(arrCommandType);
+      const isFile = existsSync("./test.txt");
+      assert(isFile, true);
+    });
+  });
+  /* this test cannot delete the file because the cmd
+   * spawned keeps the file created open
+   */
+}


### PR DESCRIPTION
## Description

Opens `cmd` for windows and gnome-terminal for linux based systems with user-specified command and gives the user complete access to the terminal window as it is detached from the program.

## Changes

The changes apply to the ergo/electron folder which has a platform folder, this folder exports functions based on the OS
currently exports only the `openTerm.js` file

## Issue

> Closes #21 and  #2 
 
## Impacted Area

Created a backend utility function

## Steps to test

Steps needed to reproduce the scenario from this change to validate if the pull request solve this issue

-  `npm run test`
- while testing on windows make sure that you will have to delete the file manually because the `cmd` spawned keeps it open 
in its process, so u will see error `EBUSY` can't unlink file, resource is busy/ being used



